### PR TITLE
Fix exceptions when Traces and 3DFaces have 4 coordinates

### DIFF
--- a/DXFLib/DXF3DFace.cs
+++ b/DXFLib/DXF3DFace.cs
@@ -8,7 +8,7 @@ namespace DXFLib
     [Entity("3DFACE")]
     public class DXF3DFace : DXFEntity
     {
-        private DXFPoint[] corners = new DXFPoint[] { new DXFPoint(), new DXFPoint(), new DXFPoint() };
+        private DXFPoint[] corners = new DXFPoint[] { new DXFPoint(), new DXFPoint(), new DXFPoint(), new DXFPoint() };
         public DXFPoint[] Corners { get { return corners; } }
 
         [Flags]

--- a/DXFLib/DXFTrace.cs
+++ b/DXFLib/DXFTrace.cs
@@ -10,7 +10,7 @@ namespace DXFLib
     {
         private DXFPoint extrusion = new DXFPoint();
         public DXFPoint ExtrusionDirection { get { return extrusion; } }
-        private DXFPoint[] corners = new DXFPoint[] { new DXFPoint(), new DXFPoint(), new DXFPoint() };
+        private DXFPoint[] corners = new DXFPoint[] { new DXFPoint(), new DXFPoint(), new DXFPoint(), new DXFPoint() };
         public DXFPoint[] Corners { get { return corners; } }
 
         public double Thickness { get; set; }


### PR DESCRIPTION
Fix exceptions when Traces and 3DFaces have 4 coordinates.

This is the same as the fix for SOLIDS with 4 coordinates.
